### PR TITLE
[DEB] hyprland (unstable): Update libinput-dev dependency to version >= 1.28

### DIFF
--- a/hyprland/debian/control
+++ b/hyprland/debian/control
@@ -23,7 +23,7 @@ Build-Depends:
  libcairo2-dev,
  libpango1.0-dev,
  libdrm-dev,
- libinput-dev,
+ libinput-dev (>=1.28),
  libxcb-xfixes0-dev,
  libxcb-icccm4-dev,
  libxcb-composite0-dev,

--- a/hyprland/jammy.sh
+++ b/hyprland/jammy.sh
@@ -7,3 +7,16 @@ echo jammy-01-opengl.patch >> debian/patches/series
 echo jammy-02-dma.patch >> debian/patches/series
 echo jammy-03-cairo.patch >> debian/patches/series
 echo jammy-04-libinput.patch >> debian/patches/series
+patch -p1 <<- "EOF"
+-- a/debian/control
++++ b/debian/control
+@@ -23,7 +23,7 @@ Build-Depends:
+  libcairo2-dev,
+  libpango1.0-dev,
+  libdrm-dev,
++ libinput-dev,
+- libinput-dev (>=1.28),
+  libxcb-xfixes0-dev,
+  libxcb-icccm4-dev,
+  libxcb-composite0-dev,
+EOF


### PR DESCRIPTION
A `hyperland (unstable)` package build error on Ubuntu Plucky is being caused by an unsatisfied `libinput` dependency.
The required version is >=1.28, but the Ubuntu upstream version is 1.27.1.

Build error message:
```
 --   Package dependency requirement 'libinput >= 1.28' could not be satisfied.
Package 'libinput' has version '1.27.1', required version is '>= 1.28'
CMake Error at /usr/share/cmake-3.31/Modules/FindPkgConfig.cmake:645 (message):
  The following required packages were not found:
   - libinput>=1.28
```