### PR TITLE
Add hyprland-protocols build dep for xdph

### DIFF
--- a/xdg-desktop-portal-hyprland/debian/control
+++ b/xdg-desktop-portal-hyprland/debian/control
@@ -24,6 +24,7 @@ Build-Depends:
  libhyprlang-dev (>= 0.2.0),
  libhyprutils-dev (>= 0.2.6),
  hyprwayland-scanner (>= 0.4.2),
+ hyprland-protocols,
 Standards-Version: 4.6.2
 Homepage: https://hyprland.org
 Vcs-Browser: https://github.com/hyprwm/xdg-desktop-portal-hyprland


### PR DESCRIPTION
Can't build without it.

```
-- Checking for module 'hyprland-protocols'
--   Package 'hyprland-protocols', required by 'virtual:world', not found

...

[ 19%] Generating /build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10/protocols/wlr-foreign-toplevel-management-unstable-v1.cpp, /build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10/protocols/wlr-foreign-toplevel-management-unstable-v1.hpp
Couldn't load proto
[ 22%] Generating /build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10/protocols/linux-dmabuf-v1.cpp, /build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10/protocols/linux-dmabuf-v1.hpp
make[3]: *** [CMakeFiles/xdg-desktop-portal-hyprland.dir/build.make:112: /build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10/protocols/hyprland-toplevel-mapping-v1.cpp] Error 1
make[3]: *** Waiting for unfinished jobs....
cd /build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10 && hyprwayland-scanner --wayland-enums --client //usr/share/wayland/wayland.xml /build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10/protocols/
cd /build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10 && hyprwayland-scanner --client /build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10/subprojects/hyprland-protocols/protocols/hyprland-toplevel-export-v1.xml /build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10/protocols/
cd /build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10 && hyprwayland-scanner --client /build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10/protocols/wlr-foreign-toplevel-management-unstable-v1.xml /build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10/protocols/
Couldn't load proto
make[3]: *** [CMakeFiles/xdg-desktop-portal-hyprland.dir/build.make:98: /build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10/protocols/hyprland-global-shortcuts-v1.cpp] Error 1
cd /build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10 && hyprwayland-scanner --client //usr/share/wayland-protocols/stable/linux-dmabuf/linux-dmabuf-v1.xml /build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10/protocols/
make[3]: Leaving directory '/build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10/obj-x86_64-linux-gnu'
Couldn't load proto
make  -f hyprland-share-picker/CMakeFiles/hyprland-share-picker_autogen_timestamp_deps.dir/build.make hyprland-share-picker/CMakeFiles/hyprland-share-picker_autogen_timestamp_deps.dir/build
make[3]: *** [CMakeFiles/xdg-desktop-portal-hyprland.dir/build.make:105: /build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10/protocols/hyprland-toplevel-export-v1.cpp] Error 1
make[3]: Entering directory '/build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10/obj-x86_64-linux-gnu'
make[3]: Nothing to be done for 'hyprland-share-picker/CMakeFiles/hyprland-share-picker_autogen_timestamp_deps.dir/build'.
make[3]: Leaving directory '/build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10/obj-x86_64-linux-gnu'
make[3]: Leaving directory '/build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10/obj-x86_64-linux-gnu'
make[2]: *** [CMakeFiles/Makefile2:113: CMakeFiles/xdg-desktop-portal-hyprland.dir/all] Error 2
make[2]: *** Waiting for unfinished jobs....
[ 22%] Built target hyprland-share-picker_autogen_timestamp_deps
make[2]: Leaving directory '/build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10/obj-x86_64-linux-gnu'
make[1]: *** [Makefile:139: all] Error 2
make[1]: Leaving directory '/build/reproducible-path/xdg-desktop-portal-hyprland-1.3.10/obj-x86_64-linux-gnu'
dh_auto_build: error: cd obj-x86_64-linux-gnu && make -j14 "INSTALL=install --strip-program=true" VERBOSE=1 returned exit code 2
make: *** [debian/rules:23: binary] Error 25
dpkg-buildpackage: error: debian/rules binary subprocess returned exit status 2
```