### PR TITLE
[DEB] hyprpolkitagent: Make `hyprland-qt-support0` a dependency

### DIFF
--- a/hyprpolkitagent/debian/control
+++ b/hyprpolkitagent/debian/control
@@ -32,5 +32,6 @@ Depends:
  qml6-module-qtquick-layouts,
  qml6-module-qtquick-templates,
  qml6-module-qtqml-workerscript,
+ hyprland-qt-support0,
 Description: hyprpolkitagent is a polkit authentication daemon
  It is required for GUI applications to be able to request elevated privileges.


### PR DESCRIPTION
Without `hyprland-qt-support0` the authentication dialog doesn't open:
```
> New authentication session
Spawning qml prompt
QQmlApplicationEngine failed to load component
qrc:/qt/qml/hpa/qml/main.qml: module "org.hyprland.style" is not installed
REQUEST
> PKS request: Password:  echo: false
```
This has become apparent after Hyprland switched to `hyprland-guiutils` and dropped `hyprland-qt-utils`, which depends on `hyprland-qt-support0`. 