### PR TITLE
[DEB] hyprpolkitagent: Provide polkit-1-auth-agent

### DIFF
--- a/hyprpolkitagent/debian/changelog
+++ b/hyprpolkitagent/debian/changelog
@@ -1,3 +1,9 @@
+hyprpolkitagent (0.1.3-1ppa3) noble; urgency=medium
+
+  * Rebuild to set `Provides`
+
+ -- Constantin Piber <cp.piber@gmail.com>  Sun, 09 Aug 2026 18:15:17 +0200
+
 hyprpolkitagent (0.1.3-1ppa2) noble; urgency=medium
 
   * Rebuild for new runtime dependency

--- a/hyprpolkitagent/debian/control
+++ b/hyprpolkitagent/debian/control
@@ -33,5 +33,7 @@ Depends:
  qml6-module-qtquick-templates,
  qml6-module-qtqml-workerscript,
  hyprland-qt-support0,
+Provides:
+ polkit-1-auth-agent,
 Description: hyprpolkitagent is a polkit authentication daemon
  It is required for GUI applications to be able to request elevated privileges.


### PR DESCRIPTION
This makes `hyprpolkitagent` provide the `polkit-1-auth-agent` package.
Allowing it to satisfy dependencies that require a PolicyKit authentication agent. 
In my case this is necessary for network-manager-applet to not pull in policykit-1-gnome or gnome-shell.